### PR TITLE
Entered missing ')' in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@
           tsCompiler: 'esbuild',
         })
       ]
-    }
+    })
     ```  
 
 3. Update your server entry to export your app named `viteNodeApp` or the name you configured.


### PR DESCRIPTION
Saw that a closing parenthese was missing on line 60 in the README.md file when I copied the code from the browser. Added. 