### PR TITLE
Using vite plugin node for svelte kit

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export declare type RequestAdapter<App = any> = (
   app: App,
   req: http.IncomingMessage,
   res: http.ServerResponse,
+  next: (err?: Error) => void,
   server: ViteDevServer
 ) => void | Promise<void>;
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -67,7 +67,8 @@ export const createMiddleware = (
 
   return async function (
     req: http.IncomingMessage,
-    res: http.ServerResponse
+    res: http.ServerResponse,
+    next: (err?: Error) => void,
   ): Promise<void> {
     const appModule = await server.ssrLoadModule(config.appPath);
     let app = appModule[config.exportName!];
@@ -79,7 +80,7 @@ export const createMiddleware = (
     } else {
       // some app may be created with a function returning a promise
       app = await app;
-      await requestHandler(app, req, res, server);
+      await requestHandler(app, req, res, next, server);
     }
   };
 };


### PR DESCRIPTION
Hi there, 
I want to make this PR so that it is possible to use this plugin for @svelte/kit. 


This pr in current form will create breakage to #25, but I would still like to introduce it so that it will play nicely with sveltekit.   
Currently there is extensive discussion that the node adapter for the svelte kit is limited especially during the development.

Essentially, I want to pass next parameter to adapter function for the following usage:
```javascript
async (app, req, res, next, server) => {
  // app here is fastify for example
  app.setDefaultRoute(() => next())
  await app.ready()
  app.routing(req, res)
}
``` 
The reason why it is necessary is that the sveltekit also mess with middleware. So that it remove the assumption that the vite-plugin-node is the end of all middleware.

I do hope you can consider this change as it greatly helps a lot of the discussion of sveltekit. For example sveltejs/kit#4654