### PR TITLE
fix: [GH-99] Explicitly import http types

### DIFF
--- a/packages/vite-plugin-node/src/index.ts
+++ b/packages/vite-plugin-node/src/index.ts
@@ -1,4 +1,4 @@
-import type http from 'http';
+import type { IncomingMessage, ServerResponse } from 'http';
 import type { Options } from '@swc/core';
 import type { Connect, UserConfig, ViteDevServer } from 'vite';
 
@@ -17,8 +17,8 @@ export declare type SupportedFrameworks =
 export declare interface RequestAdapterParams<App> {
   app: App
   server: ViteDevServer
-  req: http.IncomingMessage
-  res: http.ServerResponse
+  req: IncomingMessage
+  res: ServerResponse
   next: Connect.NextFunction
 }
 

--- a/packages/vite-plugin-node/src/server/index.ts
+++ b/packages/vite-plugin-node/src/server/index.ts
@@ -1,4 +1,4 @@
-import type http from 'http';
+import type { IncomingMessage, ServerResponse } from 'http';
 import { exit } from 'process';
 import chalk from 'chalk';
 import type {
@@ -78,8 +78,8 @@ export const createMiddleware = async (
   }
 
   return async function (
-    req: http.IncomingMessage,
-    res: http.ServerResponse,
+    req: IncomingMessage,
+    res: ServerResponse,
     next: Connect.NextFunction,
   ): Promise<void> {
     const appModule = await server.ssrLoadModule(config.appPath);


### PR DESCRIPTION
Explicitly import http types to fix "Module 'http' has no default export." error