### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@
        })
      ],
      optimizeDeps: {
-       // Vite does not work well with optionnal dependencies,
+       // Vite does not work well with optional dependencies,
        // you can mark them as ignored for now
-       // eg: for nestjs, exlude these optional dependencies:
+       // eg: for nestjs, exclude these optional dependencies:
        // exclude: [
        //   '@nestjs/microservices',
        //   '@nestjs/websockets',

--- a/packages/vite-plugin-node/readme.md
+++ b/packages/vite-plugin-node/readme.md
@@ -84,9 +84,9 @@
        })
      ],
      optimizeDeps: {
-       // Vite does not work well with optionnal dependencies,
+       // Vite does not work well with optional dependencies,
        // you can mark them as ignored for now
-       // eg: for nestjs, exlude these optional dependencies:
+       // eg: for nestjs, exclude these optional dependencies:
        // exclude: [
        //   '@nestjs/microservices',
        //   '@nestjs/websockets',


### PR DESCRIPTION
I fixed a typo in the viteconfig example.

I ran cspell on the copied viteconfig and it was detected!