### PR TITLE
Fix stack traces in express adapter

### DIFF
--- a/packages/vite-plugin-node/src/server/express.ts
+++ b/packages/vite-plugin-node/src/server/express.ts
@@ -1,6 +1,14 @@
 import type { Application } from 'express';
 import type { RequestAdapter } from '..';
 
-export const ExpressHandler: RequestAdapter<Application> = ({ app, req, res }) => {
+export const ExpressHandler: RequestAdapter<Application> = ({ app, req, res, server, next: nextType }) => {
+  // Add error handling middleware to fix stack traces
+  app.use((err: unknown, _req: typeof req, _res: typeof res, next: typeof nextType) => {
+    if (err instanceof Error)
+      server.ssrFixStacktrace(err);
+
+    next(err);
+  });
+
   app(req, res);
 };


### PR DESCRIPTION
Closes https://github.com/axe-me/vite-plugin-node/issues/119

Using the reproducer from the linked issue, here's the before and after results:

## Before

```
Error: This error produces a stack trace that is incorrect.
    at eval (/Users/dennisameling/repos/vite-plugin-node-stack-bug/src/server.ts:8:9)
    at Layer.handle [as handle_request] (/Users/dennisameling/repos/vite-plugin-node-stack-bug/node_modules/express/lib/router/layer.js:95:5)
    at next (/Users/dennisameling/repos/vite-plugin-node-stack-bug/node_modules/express/lib/router/route.js:149:13)
    at Route.dispatch (/Users/dennisameling/repos/vite-plugin-node-stack-bug/node_modules/express/lib/router/route.js:119:3)
    at Layer.handle [as handle_request] (/Users/dennisameling/repos/vite-plugin-node-stack-bug/node_modules/express/lib/router/layer.js:95:5)
    at /Users/dennisameling/repos/vite-plugin-node-stack-bug/node_modules/express/lib/router/index.js:284:15
    at Function.process_params (/Users/dennisameling/repos/vite-plugin-node-stack-bug/node_modules/express/lib/router/index.js:346:12)
    at next (/Users/dennisameling/repos/vite-plugin-node-stack-bug/node_modules/express/lib/router/index.js:280:10)
    at expressInit (/Users/dennisameling/repos/vite-plugin-node-stack-bug/node_modules/express/lib/middleware/init.js:40:5)
    at Layer.handle [as handle_request] (/Users/dennisameling/repos/vite-plugin-node-stack-bug/node_modules/express/lib/router/layer.js:95:5)
```

## After

```
Error: This error produces a stack trace that is incorrect.
    at /Users/dennisameling/repos/vite-plugin-node-stack-bug/src/server.ts:10:9
    at Layer.handle [as handle_request] (/Users/dennisameling/repos/vite-plugin-node-stack-bug/node_modules/express/lib/router/layer.js:95:5)
    at next (/Users/dennisameling/repos/vite-plugin-node-stack-bug/node_modules/express/lib/router/route.js:149:13)
    at Route.dispatch (/Users/dennisameling/repos/vite-plugin-node-stack-bug/node_modules/express/lib/router/route.js:119:3)
    at Layer.handle [as handle_request] (/Users/dennisameling/repos/vite-plugin-node-stack-bug/node_modules/express/lib/router/layer.js:95:5)
    at /Users/dennisameling/repos/vite-plugin-node-stack-bug/node_modules/express/lib/router/index.js:284:15
    at Function.process_params (/Users/dennisameling/repos/vite-plugin-node-stack-bug/node_modules/express/lib/router/index.js:346:12)
    at next (/Users/dennisameling/repos/vite-plugin-node-stack-bug/node_modules/express/lib/router/index.js:280:10)
    at expressInit (/Users/dennisameling/repos/vite-plugin-node-stack-bug/node_modules/express/lib/middleware/init.js:40:5)
    at Layer.handle [as handle_request] (/Users/dennisameling/repos/vite-plugin-node-stack-bug/node_modules/express/lib/router/layer.js:95:5)
```