### PR TITLE
feat: added rollupOptions to config for overriding them

### DIFF
--- a/packages/vite-plugin-node/src/index.ts
+++ b/packages/vite-plugin-node/src/index.ts
@@ -1,6 +1,6 @@
 import type { IncomingMessage, ServerResponse } from 'http';
 import type { Options } from '@swc/core';
-import type { Connect, UserConfig, ViteDevServer } from 'vite';
+import type { BuildOptions, Connect, UserConfig, ViteDevServer } from 'vite';
 
 export { RollupPluginSwc } from './rollup-plugin-swc';
 export { VitePluginNode } from './vite-plugin-node';
@@ -39,6 +39,7 @@ export interface VitePluginNodeConfig {
   tsCompiler?: SupportedTSCompiler
   swcOptions?: Options
   outputFormat?: ModuleFormat
+  rollupOptions?: BuildOptions["rollupOptions"]
 }
 
 export declare interface ViteConfig extends UserConfig {

--- a/packages/vite-plugin-node/src/vite-plugin-node.ts
+++ b/packages/vite-plugin-node/src/vite-plugin-node.ts
@@ -31,6 +31,7 @@ export function VitePluginNode(cfg: VitePluginNodeConfig): Plugin[] {
     exportName: cfg.exportName ?? 'viteNodeApp',
     initAppOnBoot: cfg.initAppOnBoot ?? false,
     outputFormat: cfg.outputFormat ?? 'cjs',
+    rollupOptions: cfg.rollupOptions ?? {},
     swcOptions,
   };
 
@@ -46,6 +47,7 @@ export function VitePluginNode(cfg: VitePluginNodeConfig): Plugin[] {
               output: {
                 format: config.outputFormat,
               },
+              ...config.rollupOptions,
             },
           },
           server: {


### PR DESCRIPTION
Hey all,

Simple PR here to add `rollupOptions` to just override `input` and `output` - there's a lot of case by case need for these options such as splitting module entries for other purposes.

Please any suggestions to make it better.

Thanks